### PR TITLE
docs: Clean up README and remove initial setup clutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,67 +1,41 @@
-\# Grafana Loki Log Monitor Dashboard 🚀
+# Grafana Loki Log Monitor Dashboard 🚀
 
+A test setup for simulating production-style log monitoring using Docker, Grafana, Loki, Promtail, and PowerShell.
 
+Designed to generate fake HTTP success traffic and visualize real-time ingestion using Grafana dashboards powered by LogQL.
 
-Test simulation of production-style log monitoring stack built with Docker, Grafana, Loki, Promtail, and PowerShell.  
+## 📦 Stack Overview
 
-Designed to simulate real-time HTTP success traffic using a log spammer and visualize it through a Grafana dashboard.
+- **Grafana** – Dashboard & visualization
+- **Loki** – Log aggregation backend
+- **Promtail** – Log shipper from file
+- **PowerShell** – Custom log generator
+- **Docker Compose** – Local dev orchestration
 
+## 🎯 What This Dashboard Shows
 
+- 🔢 HTTP Successes (Last 5m) – Total logs ingested from a fake HTTP success loop
+- 📈 Success Rate (req/s) – Real-time line graph showing log spike frequency
+- ⚙️ Powered by LogQL queries like:
+  - `rate({job="spammer"} |= "HTTP client success"[1m])`
+  - `count_over_time({job="spammer"} |= "HTTP client success"[5m])`
 
----
+## ⚙️ How to Run
 
+1. Clone the repo:
+   ```bash
+   git clone https://github.com/professorpoof/lowkey-loki-logs.git
+   cd lowkey-loki-logs
+   ```
 
+2. Start the stack:
+   ```bash
+   docker-compose up
+   ```
 
-\## 📦 Stack Overview
+3. Access Grafana:
+   - http://localhost:3000  
+   - Login: `admin` / `admin`
 
-
-
-\- \*\*Grafana\*\* – Dashboard \& visualization
-
-\- \*\*Loki\*\* – Log aggregation backend
-
-\- \*\*Promtail\*\* – Log shipper from file
-
-\- \*\*PowerShell\*\* – Custom log generator
-
-\- \*\*Docker Compose\*\* – Local dev orchestration
-
-
-
----
-
-
-
-\## 🎯 What This Dashboard Shows
-
-
-
-\- 🔢 `HTTP Successes (Last 5m)` – Total logs ingested from a fake HTTP success loop  
-
-\- 📈 `Success Rate (req/s)` – Real-time line graph showing log spike frequency  
-
-\- ⚙️ Powered by LogQL queries like:
-
-&nbsp; - `rate({job="spammer"} |= "HTTP client success"\[1m])`
-
-&nbsp; - `count\_over\_time({job="spammer"} |= "HTTP client success"\[5m])`
-
-
-
----
-
-
-
-\## ⚙️ How to Run
-
-
-
-\### 1. Clone the repo:
-
-```bash
-
-git clone https://github.com/your-username/grafana-loki-dashboard.git
-
-cd grafana-loki-dashboard
-
-🧪 Testing PR creation from feature/docs-update
+4. Import the dashboard:
+   - File: `grafana-dashboard.json`


### PR DESCRIPTION
- Rewrote and reformatted README for clarity and correctness
- Fixed repo path in clone instructions
- Deleted unused `initial-setup` local branch to clean up leftovers from branch rename

This PR wraps the cleanup so `main` stays tidy and accurate.
